### PR TITLE
Add AI dialog app for Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# AI Dialogue Netlify
+
+Aplicación simple que muestra un diálogo entre dos inteligencias artificiales.
+
+## Uso
+
+1. Definir la variable de entorno `OPENAI_API_KEY`.
+2. Ejecutar la función en Netlify:
+   - Subir este repositorio a Netlify.
+   - Cada petición a `/.netlify/functions/dialog` inicia una conversación.
+3. Se puede ajustar el número de interacciones y tokens por llamada usando parámetros de consulta `interactions` y `max_tokens`.
+
+## Desarrollo local
+
+```bash
+npm test
+```

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[functions]
+  directory = "netlify/functions"

--- a/netlify/functions/dialog.js
+++ b/netlify/functions/dialog.js
@@ -1,0 +1,59 @@
+const { parseLimits } = require('../../utils/limits');
+
+async function fetchCompletion(apiKey, role, prompt, maxTokens) {
+  const systemPrompt = role === 'Alpha'
+    ? 'You are AI Alpha. Respond concisely to AI Beta.'
+    : 'You are AI Beta. Respond concisely to AI Alpha.';
+
+  const body = {
+    model: 'gpt-3.5-turbo',
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: prompt }
+    ],
+    max_tokens: maxTokens,
+    temperature: 0.7
+  };
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(body)
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`OpenAI error: ${err}`);
+  }
+  const data = await res.json();
+  return data.choices[0].message.content.trim();
+}
+
+exports.handler = async function(event) {
+  const { interactions, max_tokens } = parseLimits(event.queryStringParameters);
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Missing OPENAI_API_KEY' }) };
+  }
+
+  const conversation = [];
+  let alphaMsg = 'Hola Beta, ¿cómo estás?';
+  conversation.push({ speaker: 'Alpha', message: alphaMsg });
+
+  for (let i = 0; i < interactions; i++) {
+    const betaMsg = await fetchCompletion(apiKey, 'Beta', alphaMsg, max_tokens);
+    conversation.push({ speaker: 'Beta', message: betaMsg });
+
+    alphaMsg = await fetchCompletion(apiKey, 'Alpha', betaMsg, max_tokens);
+    conversation.push({ speaker: 'Alpha', message: alphaMsg });
+  }
+
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ conversation })
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai-dialog-netlify",
+  "version": "1.0.0",
+  "description": "App where two AIs converse with token and interaction limits",
+  "main": "index.js",
+  "scripts": {
+    "test": "node tests/limits.test.js"
+  },
+  "keywords": ["ai", "netlify", "dialog"],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Diálogo entre IA</title>
+</head>
+<body>
+  <h1>Diálogo entre dos IA</h1>
+  <button id="run">Iniciar conversación</button>
+  <pre id="log"></pre>
+  <script>
+    document.getElementById('run').onclick = async () => {
+      const res = await fetch('/.netlify/functions/dialog?interactions=3&max_tokens=60');
+      const data = await res.json();
+      const output = data.conversation.map(c => `${c.speaker}: ${c.message}`).join('\n');
+      document.getElementById('log').textContent = output;
+    };
+  </script>
+</body>
+</html>

--- a/tests/limits.test.js
+++ b/tests/limits.test.js
@@ -1,0 +1,16 @@
+const { parseLimits } = require('../utils/limits');
+
+const cases = [
+  [{ interactions: '5', max_tokens: '100' }, { interactions: 5, max_tokens: 100 }],
+  [{ interactions: '50', max_tokens: '500' }, { interactions: 20, max_tokens: 200 }]
+];
+
+for (const [input, expected] of cases) {
+  const out = parseLimits(input);
+  if (out.interactions !== expected.interactions || out.max_tokens !== expected.max_tokens) {
+    console.error('Test failed', { input, out, expected });
+    process.exit(1);
+  }
+}
+
+console.log('All tests passed.');

--- a/utils/limits.js
+++ b/utils/limits.js
@@ -1,0 +1,9 @@
+function parseLimits(params = {}) {
+  const MAX_INTERACTIONS = 20;
+  const MAX_TOKENS = 200;
+  const interactions = Math.min(parseInt(params.interactions || '5', 10), MAX_INTERACTIONS);
+  const max_tokens = Math.min(parseInt(params.max_tokens || '60', 10), MAX_TOKENS);
+  return { interactions, max_tokens };
+}
+
+module.exports = { parseLimits };


### PR DESCRIPTION
## Summary
- add Netlify function that runs a dialogue between two AIs with configurable interaction and token limits
- include simple web interface to trigger conversation
- document usage and add basic limit parsing tests

## Testing
- `npm test`
- `npm install openai` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c00e0eba38832697b176069699dc1b